### PR TITLE
fix: email을 기반으로 User를 찾고 유저가 없으면 null 리턴

### DIFF
--- a/core/src/main/java/io/devarium/core/domain/user/service/UserServiceImpl.java
+++ b/core/src/main/java/io/devarium/core/domain/user/service/UserServiceImpl.java
@@ -39,8 +39,7 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public User getByEmail(String email) {
-        return userRepository.findByEmail(email)
-            .orElseThrow(() -> new UserException(UserErrorCode.USER_EMAIL_NOT_FOUND, email));
+        return userRepository.findByEmail(email).orElse(null);
     }
 
     @Override


### PR DESCRIPTION
- 이메일이 없으면 가입을 진행해야하는 기존 코드는 예외발생으로 유저의 생성으로 이어질 수 없음